### PR TITLE
Edit raspberry-pi2-openmp.c and README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,10 @@ Build (gcc 4.3 or later)
  * To compile using gcc with Cilkplus 
    gcc -fcilkplus -Wall -O2 -o raspberry-pi2-cilk raspberry-pi2-cilk.c -lgmp -lm
 
+Build (clang/llvm 3.7 or later)
 
+ * To compile using clang/llvm with OpenMP
+   clang -fopenmp -o raspberry-pi2-openmp raspberry-pi2-openmp.c -lgmp -lm
 
+ * To compile using clang/llvm with Cilkplus
+   clang -fcilkplus -Wall -O2 -o raspberry-pi2-cilk raspberry-pi2-cilk.c -lgmp -lm

--- a/raspberry-pi2-openmp.c
+++ b/raspberry-pi2-openmp.c
@@ -61,6 +61,10 @@
 #define DIGITS_PER_ITER  14.1816474627254776555
 #define DOUBLE_PREC      53
 
+#if defined(__GNUC__) && !defined(__clang__) && !defined(__INTEL_COMPILER)
+# define GCC_COMPILER 1
+#endif
+
 long terms;
 char *prog_name;
 
@@ -245,8 +249,16 @@ main(int argc,char *argv[])
     threads = atoi(argv[3]);
 
   cores=omp_get_num_procs();
-  omp_set_nested(1);
-  omp_set_dynamic(0);
+  int t_dynamic = 0;
+  t_dynamic = omp_get_dynamic();
+  omp_set_dynamic(t_dynamic);
+  #if GCC_COMPILER
+    int t_nested = omp_get_nested();
+    omp_set_nested(t_nested);
+  #endif
+  int t_levels = 3;
+  t_levels = omp_get_max_active_levels();
+  omp_set_max_active_levels(t_levels);
 
   terms = d/DIGITS_PER_ITER;
   depth = 0;


### PR DESCRIPTION
## OpenMP nested routines are deprecated
Other than with gcc, checks are used to avoid this deprecation warning.
This is similar to the fix from marioroy/Chudnovsky-Pi#1.
## Building with gcc or clang/llvm
- gcc 11 with `lld` linker
```
String dump of section '.comment':
  [     0]  GCC: (Ubuntu 11.1.0-1ubuntu1~20.04) 11.1.0
  [    2b]  Linker: Ubuntu LLD 15.0.0
```
- clang 13 with `mold` linker
```
String dump of section '.comment':
  [     0]  mold 1.1 (b0d91b99676b7ea7a5f255f5caf6f8b01985fb82; compatible with GNU ld)
  [    4c]  clang version 13.0.1
  [    61]  Android (7714059, based on r416183c1) clang version 12.0.8 (https://android.googlesource.com/toolchain/llvm-project c935d99d7cf2016289302412d708641d52d2f7ee)
```